### PR TITLE
improve logging

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,7 +7,14 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve log handling:
+
+  * only log errors during startup
+  * log INFO to stdout
+  * log ERROR to stderr
+
+  This makes it possible to only escalate errors in cronjobs and send
+  normal logging to /dev/null
 
 
 1.0.3 (2016-05-19)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
   This makes it possible to only escalate errors in cronjobs and send
   normal logging to /dev/null
 
+  [frisi]
+
 
 1.0.3 (2016-05-19)
 ------------------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,9 +12,11 @@ Changelog
   * only log errors during startup
   * log INFO to stdout
   * log ERROR to stderr
+  * log to instance's event.log too
 
-  This makes it possible to only escalate errors in cronjobs and send
-  normal logging to /dev/null
+  This makes it possible to only escalate errors in cronjobs, send
+  normal logging to /dev/null and protocol what has been done in
+  the instance.log
 
   [frisi]
 

--- a/src/slc/zopescript/script.py
+++ b/src/slc/zopescript/script.py
@@ -26,7 +26,7 @@ class ConsoleScript(object):
         # and init the instance's event.log
         log.handlers = []
         if starter.cfg.eventlog is not None:
-             starter.cfg.eventlog()
+            starter.cfg.eventlog()
         log.setLevel(0)
 
         # add 2 handlers: INFO to stdout, ERROR to stderr

--- a/src/slc/zopescript/script.py
+++ b/src/slc/zopescript/script.py
@@ -18,15 +18,18 @@ class ConsoleScript(object):
         # we're only interested in ERRORs during startup
         log.setLevel(logging.ERROR)
 
-        Zope2.Startup.run.configure(config_file)
+        starter = Zope2.Startup.run.configure(config_file)
         environ['SERVER_URL'] = server_url
         self.app = makerequest(Zope2.app(), environ=environ)
 
-        # after startup, remove the StarupHandler and reset level
+        # after startup, remove the StartupHandler
+        # and init the instance's event.log
         log.handlers = []
+        if starter.cfg.eventlog is not None:
+             starter.cfg.eventlog()
         log.setLevel(0)
 
-        # 2 handlers: INFO to stdout, ERROR to stderr
+        # add 2 handlers: INFO to stdout, ERROR to stderr
         stdout = logging.StreamHandler(sys.stdout)
         stderr = logging.StreamHandler(sys.stderr)
         formatter = logging.Formatter(


### PR DESCRIPTION
* separate handlers for stderr (level==ERROR) and stdout (level=INFO)
* during zope startup, only output ERRORS
* also log to instances' event.log if it is configured in zope.conf