### PR TITLE
Prevent the log level getting set to DEBUG

### DIFF
--- a/src/slc/zopescript/script.py
+++ b/src/slc/zopescript/script.py
@@ -19,7 +19,8 @@ class InstanceScript(object):
         environ['SERVER_URL'] = server_url
         self.app = makerequest(self.app, environ=environ)
 
-        log.setLevel(0)
+        log.handlers = []
+        log.setLevel(logging.NOTSET)
 
         # add 2 handlers: INFO to stdout, ERROR to stderr
         stdout = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
If we don't clear the handlers, then the log level gets set to DEBUG for InstanceScripts